### PR TITLE
Update Substring startIndex value to 4 in Get-AzureSizingInfo.ps1

### DIFF
--- a/CLOUD/Get-AzureSizingInfo.ps1
+++ b/CLOUD/Get-AzureSizingInfo.ps1
@@ -1574,7 +1574,7 @@ if ($Anonymize) {
             $tagValue = $DataObject.$propertyName
             $anonymizedTagKey = ""
             
-            $tagName = $propertyName.Substring(10)
+            $tagName = $propertyName.Substring(4)
             
             if (-not $global:anonymizeDict.ContainsKey("$tagName")) {
                 $global:anonymizeDict["$tagName"] = Get-NextAnonymizedValue("TagName")


### PR DESCRIPTION
Since the support for Tags instead of Labels per Azure's change was added (commit ec92079), the Substring startIndex value was left to 10 which is incorrect. The value has now been updated to 4.